### PR TITLE
Use nulled GameService in VueControllerWebTest

### DIFF
--- a/src/test/java/com/jitterted/yacht/adapter/in/vue/VueControllerWebTest.java
+++ b/src/test/java/com/jitterted/yacht/adapter/in/vue/VueControllerWebTest.java
@@ -1,9 +1,13 @@
 package com.jitterted.yacht.adapter.in.vue;
 
+import com.jitterted.yacht.application.GameService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
@@ -17,6 +21,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @Tag("spring")
 public class VueControllerWebTest {
+
+    @TestConfiguration
+    public static class Configuration {
+        @Bean
+        @Primary
+        GameService createNullGameService() {
+            return GameService.createNull();
+        }
+    }
+
     @Autowired
     private MockMvc mockMvc;
 


### PR DESCRIPTION
This PR fixes the failing test `postToAssignCategorySucceeds` by adding a `@TestConfiguration` to override the `GameService` bean to `GameService.createNull()`.
